### PR TITLE
chore: fix typo in release docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,8 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           file: ./docker/binary.Dockerfile
           tags: |
-            tensorchord/pg_tokenizer-binary:pg${{ matrix.version }}-v${{ env.SEMVER }}-${{ env.PLATFORM }}
-            ghcr.io/tensorchord/pg_tokenizer-binary:pg${{ matrix.version }}-v${{ env.SEMVER }}-${{ env.PLATFORM }}
+            tensorchord/pg_tokenizer-binary:pg${{ matrix.version }}-v${{ env.SEMVER }}
+            ghcr.io/tensorchord/pg_tokenizer-binary:pg${{ matrix.version }}-v${{ env.SEMVER }}
           build-args: |
             PG_VERSION=${{ matrix.version }}
             SEMVER=${{ env.SEMVER }}


### PR DESCRIPTION
Actually, we don't set `PLATFORM` in env so that the released tag is `pg17-v0.1.0-`. After this PR, the expected tag is `pg17-v0.1.0`. We can update it in the next release.